### PR TITLE
[internal] allow some attributes to be type cast before save

### DIFF
--- a/lib/activerecord-import/import.rb
+++ b/lib/activerecord-import/import.rb
@@ -344,7 +344,7 @@ class ActiveRecord::Base
     end
 
     def import_helper( *args )
-      options = { validate: true, timestamps: true }
+      options = { validate: true, timestamps: true, type_cast: [] }
       options.merge!( args.pop ) if args.last.is_a? Hash
       # making sure that current model's primary key is used
       options[:primary_key] = primary_key
@@ -356,6 +356,8 @@ class ActiveRecord::Base
 
       is_validating = options[:validate]
       is_validating = true unless options[:validate_with_context].nil?
+
+      columns_to_type_cast = options[:type_cast]
 
       # assume array of model objects
       if args.last.is_a?( Array ) && args.last.first.is_a?(ActiveRecord::Base)
@@ -378,7 +380,11 @@ class ActiveRecord::Base
             if stored_attrs.any? && stored_attrs.key?(name.to_sym)
               model.read_attribute(name.to_s)
             else
-              model.read_attribute_before_type_cast(name.to_s)
+              if columns_to_type_cast.index(name.to_sym)
+                model.read_attribute(name.to_s)
+              else
+                model.read_attribute_before_type_cast(name.to_s)
+              end
             end
           end
         end


### PR DESCRIPTION
## Why?
- this will allow us to control when we type cast a column and when we
dont. this will be useful with rails 5 in this scenario: a column is of
the type decimal and we are trying to save its model to the database,
but that column is `nil`. if we read that column before type casting it we
would get `""`, but after type casting it would be `nil`. `nil` is what
we want because we can save that to the db, but we can't save an empty
string to the database in a decimal column with the stricter sql mode.
- this will allow us to control how we save specific columns with this
gem until we move to rails 6 which has its own bulk insert mechanism.

## What?
- we now can pass in an array of column names for the models trying to
be saved. the columns that we pass in will be type cast before we try to
save.